### PR TITLE
change @polkadot/api version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "author": "treturner",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@polkadot/api": "^6",
+    "@polkadot/api": "^4",
     "@subql/types": "latest",
     "typescript": "^4.1.3",
     "@subql/cli": "latest"


### PR DESCRIPTION
This PR fixes an issue that I observed locally:

>  npm i                                                                                                                                                                             Mon 20 Dec 16:39:47 2021
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: starterProject@1.0.0
npm ERR! Found: @polkadot/api@6.6.1
npm ERR! node_modules/@polkadot/api
npm ERR!   dev @polkadot/api@"^6" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @polkadot/api@"^4" from @subql/types@0.8.0
npm ERR! node_modules/@subql/types
npm ERR!   dev @subql/types@"latest" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.